### PR TITLE
Tiny fix for „Localization for Multilingual Sites“

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ l::set('typography.hyphenation.language', 'fr'); // … and so are hyphenation r
 # site/languages/de.php
 l::set('typography.quotes.primary', 'doubleLow9Reversed');
 l::set('typography.quotes.secondary', 'singleLow9Reversed');
-l::set('typography.hyphenation.language', 'de-DE');
+l::set('typography.hyphenation.language', 'de');
 ```
 
 At the end of this document, you can find a [list of recommended settings for different languages](#5-recommended-settings-for-different-languages), you can use as a starting point for your own configuration.


### PR DESCRIPTION
Value for `typography.hyphenation.language` can’t be `de-DE`. Should be `de` instead.